### PR TITLE
Add stubbed computeWeights.py script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+*.py[cod]
+.DS_Store
+.*.swp
+.*.swo

--- a/Python/RankAggregation/computeWeights.py
+++ b/Python/RankAggregation/computeWeights.py
@@ -1,0 +1,43 @@
+#! /usr/bin/env python
+
+"""
+This is a stubbed script to demonstrate the desired input and output format for
+pre-challenge image metric evaluation.
+"""
+
+import json
+
+
+if __name__ == '__main__':
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="Compute metric weights from ground truth for a challenge")
+    parser.add_argument("groundtruth", type=str,
+        help="path containing ground truth files")
+
+    metricWeights = {
+        "Adb1": {
+            "title": "Average distance of boundaries (label 1)",
+            "weight": -0.5
+        },
+        "Adb2": {
+            "title": "Average distance of boundaries (label 2)",
+            "weight": -0.5
+        },
+        "Hdb1": {
+            "title": "Hausdorff distance (label 1)",
+            "weight": -1
+        },
+        "Spec1": {
+            "title": "Specificity (label 1)",
+            "weight": 1
+        },
+        "Sens1": {
+            "title": "Sensitivity (label 1)",
+            "weight": 1
+        }
+        # etc
+    }
+
+    print(json.dumps(metricWeights))


### PR DESCRIPTION
@prastawa This is the stubbed script that will be used for pre-challenge initialization as we discussed last week. It should print JSON output in the format shown in the example. As input, it will receive the --groundtruth argument that will point to a directory on the local filesystem that contains the set of ground truth images. Feel free to add any other arguments that it needs, such as paths to executables within the container. If the implementation requires any non-standard python packages to be installed, we can add pip install steps for them inside the Dockerfile.
