### PR TITLE
Make random seeds in the 32-bit range

### DIFF
--- a/Python/RankAggregation/computeRankWeights.py
+++ b/Python/RankAggregation/computeRankWeights.py
@@ -1,9 +1,9 @@
 #! /usr/bin/env python
 #
 # Rank aggregation of image segmentation fidelity to ground truth using
-# unsupervised learning combined with ensemble analysis of perturbed 
+# unsupervised learning combined with ensemble analysis of perturbed
 # segmentations/registrations
-# 
+#
 # Based on
 # Klementiev, A., Roth, D., & Small, K. (2007). An unsupervised learning
 # algorithm for rank aggregation. In Machine Learning: ECML 2007 (pp. 616-623).
@@ -47,7 +47,7 @@ def getMetricValues(textFilename, numLabels):
     item  = inner.split(",")[0]
 
     value = float(value)
-    # For consistency, tag inf as nan 
+    # For consistency, tag inf as nan
     if np.isinf(value):
       value = np.nan
 
@@ -116,8 +116,8 @@ if __name__ == "__main__":
   np.set_printoptions(suppress=True)
 
   # Make multiple runs consistent
-  random.seed(2790150234680)
-  np.random.seed(78261310579)
+  random.seed(2015023468)
+  np.random.seed(261310579)
 
   startTime = time.clock()
 


### PR DESCRIPTION
This fixes an error I ran into when running inside the docker container:

```
Setting number of processes from 8 to 1
Applying 100 perturbations per ground truth
Using 1 processes
Traceback (most recent call last):
  File "/covalic/Python/RankAggregation/computeRankWeights.py", line 120, in <module>
    np.random.seed(78261310579)
  File "mtrand.pyx", line 650, in mtrand.RandomState.seed (numpy/random/mtrand/mtrand.c:7766)
ValueError: Seed must be between 0 and 4294967295
```
