### PR TITLE
Fix scoring script argument help descriptions

### DIFF
--- a/Python/scoreSubmission.py
+++ b/Python/scoreSubmission.py
@@ -86,9 +86,9 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser(
         description='Submission scoring helper script')
     parser.add_argument('-g', '--groundtruth', required=True,
-                        help='path to the ground truth zip file')
+                        help='path to the ground truth folder')
     parser.add_argument('-s', '--submission', required=True,
-                        help='path to the submission zip file')
+                        help='path to the submission folder')
     args = parser.parse_args()
 
     scoreAll(args)


### PR DESCRIPTION
Update the command line argument help descriptions to reflect that they
are now folders, not zip files.